### PR TITLE
Fix Node version for Solana library compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14-alpine
+# Use a newer Node.js version so modern syntax like logical OR assignment works
+FROM node:20-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Or...
 
 >You can check out a more detailed setup tutorial on our [wiki](https://github.com/owenashurst/agar.io-clone/wiki/Setup).
 
-#### Requirements
-To run / install this game, you'll need: 
-- NodeJS with NPM installed.
+-#### Requirements
+To run / install this game, you'll need:
+- NodeJS v16 or higher (Node 20 recommended) with NPM installed.
 - socket.IO.
 - Express.
 


### PR DESCRIPTION
## Summary
- update Node.js version in Dockerfile
- document minimum Node version in README

## Testing
- `node node_modules/gulp/bin/gulp.js test` *(fails: Cannot find module 'gulp/bin/gulp.js')*
- `npx gulp test` *(fails: unable to fetch packages without network)*