### PR TITLE
Fix Solana wallet deposit handling

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -35,7 +35,7 @@
                 <p id="walletAddress"></p>
                 <button id="generateWalletButton" disabled>Generate Game Wallet</button>
                 <p id="gameWalletAddress"></p>
-                <input id="depositAmount" type="number" placeholder="Amount (lamports)" />
+                <input id="depositAmount" type="number" placeholder="Amount (SOL)" step="0.000000001" />
                 <button id="depositButton" disabled>Deposit</button>
             </div>
             <br />


### PR DESCRIPTION
## Summary
- support Phantom wallet adapter connection
- allow deposit amount entry in SOL instead of lamports
- set transaction fields for signing with Phantom

## Testing
- `npm test` *(fails: gulp not found)*