### PR TITLE
Fix deposit flow and killing payout

### DIFF
--- a/src/client/js/global.js
+++ b/src/client/js/global.js
@@ -28,4 +28,5 @@ module.exports = {
     toggleMassState: 0,
     backgroundColor: '#f2fbff',
     lineColor: '#000000',
+    depositData: null,
 };

--- a/src/client/js/wallet-manager.js
+++ b/src/client/js/wallet-manager.js
@@ -1,4 +1,5 @@
 const web3 = require('@solana/web3.js');
+const global = require('./global');
 
 class WalletManager {
     constructor() {
@@ -25,6 +26,12 @@ class WalletManager {
     }
 
     async deposit() {
+        if (!this.connectedWallet) {
+            await this.connect();
+        }
+        if (!this.gameWallet) {
+            this.generateGameWallet();
+        }
         const amountInput = document.getElementById('depositAmount');
         const solAmount = parseFloat(amountInput.value);
         if (!solAmount || !this.connectedWallet || !this.gameWallet) return;
@@ -44,6 +51,7 @@ class WalletManager {
         const { signature } = await window.solana.signAndSendTransaction(tx);
         await connection.confirmTransaction(signature);
         this.amount = lamports;
+        global.depositData = this.getPlayerData();
         alert('Deposit sent');
     }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -308,8 +308,10 @@ const tickGame = () => {
         if (playerDied) {
             let playerGotEaten = map.players.data[gotEaten.playerIndex];
             if (playerGotEaten.escrowBalance > 0) {
-                solanaEscrow.withdraw(DEATH_BENEFICIARY, playerGotEaten.escrowBalance)
-                    .then(() => escrowRepository.recordWithdrawal(playerGotEaten.id, DEATH_BENEFICIARY, playerGotEaten.escrowBalance))
+                const killer = map.players.data[eater.playerIndex];
+                const beneficiary = killer && killer.walletAddress ? killer.walletAddress : DEATH_BENEFICIARY;
+                solanaEscrow.withdraw(beneficiary, playerGotEaten.escrowBalance)
+                    .then(() => escrowRepository.recordWithdrawal(playerGotEaten.id, beneficiary, playerGotEaten.escrowBalance))
                     .catch((e) => console.error('Transfer failed', e));
                 playerGotEaten.escrowBalance = 0;
             }


### PR DESCRIPTION
## Summary
- auto-generate a game wallet when making deposits
- track deposit data globally
- transfer escrow to killer if possible, otherwise to the default account

## Testing
- `npm test` *(fails: gulp not found)*