### PR TITLE
Fix deposit null public key

### DIFF
--- a/src/server/lib/solana-escrow.js
+++ b/src/server/lib/solana-escrow.js
@@ -10,6 +10,7 @@ const escrowKeypair = ESCROW_SECRET ? Keypair.fromSecretKey(Buffer.from(JSON.par
 const escrowPublicKey = ESCROW_PUBLIC ? new PublicKey(ESCROW_PUBLIC) : (escrowKeypair ? escrowKeypair.publicKey : null);
 
 async function deposit(fromSecret, amountLamports) {
+    if (!escrowPublicKey) throw new Error('Escrow public key not configured');
     const from = Keypair.fromSecretKey(Buffer.from(JSON.parse(fromSecret)));
     const tx = new Transaction().add(SystemProgram.transfer({
         fromPubkey: from.publicKey,


### PR DESCRIPTION
## Summary
- validate escrow public key when depositing

## Testing
- `npm test` *(fails: gulp not found)*