### PR TITLE
Handle base58 secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ docker build -t agarioclone_agar .
 docker run -it -p 3000:3000 agarioclone_agar
 ```
 
+### Solana Escrow Setup
+Set `ESCROW_PUBLIC_KEY` and optionally `ESCROW_SECRET_KEY` in your environment when starting the server. The values may be JSON arrays (as produced by `solana-keygen`) or base58 encoded strings. Providing the secret key enables withdrawals from the escrow account.
+
 ---
 
 ## FAQ


### PR DESCRIPTION
## Summary
- parse secret keys supplied as base58 strings or JSON arrays
- document Solana environment variables

## Testing
- `npm test` *(fails: gulp not found)*