### PR TITLE
Show wallet balance in game

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -365,6 +365,7 @@ function gameLoop() {
                     borderColor: borderColor,
                     mass: users[i].cells[j].mass,
                     name: users[i].name,
+                    wallet: users[i].escrowBalance,
                     radius: users[i].cells[j].radius,
                     x: users[i].cells[j].x - player.x + global.screen.width / 2,
                     y: users[i].cells[j].y - player.y + global.screen.height / 2

--- a/src/client/js/render.js
+++ b/src/client/js/render.js
@@ -1,4 +1,5 @@
 const FULL_ANGLE = 2 * Math.PI;
+const LAMPORTS_PER_SOL = 1000000000;
 
 const drawRoundObject = (position, radius, graph) => {
     graph.beginPath();
@@ -101,12 +102,25 @@ const drawCells = (cells, playerConfig, toggleMassState, borders, graph) => {
         graph.strokeText(cell.name, cell.x, cell.y);
         graph.fillText(cell.name, cell.x, cell.y);
 
+        // Wallet value below the name
+        let smallFont = Math.max(fontSize / 3 * 2, 10);
+        let offset = fontSize;
+        if (typeof cell.wallet !== 'undefined') {
+            const walletText = (cell.wallet / LAMPORTS_PER_SOL).toFixed(2) + ' SOL';
+            graph.font = 'bold ' + smallFont + 'px sans-serif';
+            graph.fillStyle = '#ff0000';
+            graph.strokeText(walletText, cell.x, cell.y + offset);
+            graph.fillText(walletText, cell.x, cell.y + offset);
+            offset += smallFont;
+            graph.fillStyle = playerConfig.textColor;
+        }
+
         // Draw the mass (if enabled)
         if (toggleMassState === 1) {
-            graph.font = 'bold ' + Math.max(fontSize / 3 * 2, 10) + 'px sans-serif';
-            if (cell.name.length === 0) fontSize = 0;
-            graph.strokeText(Math.round(cell.mass), cell.x, cell.y + fontSize);
-            graph.fillText(Math.round(cell.mass), cell.x, cell.y + fontSize);
+            graph.font = 'bold ' + smallFont + 'px sans-serif';
+            if (cell.name.length === 0 && typeof cell.wallet === 'undefined') offset = 0;
+            graph.strokeText(Math.round(cell.mass), cell.x, cell.y + offset);
+            graph.fillText(Math.round(cell.mass), cell.x, cell.y + offset);
         }
     }
 };

--- a/src/server/map/map.js
+++ b/src/server/map/map.js
@@ -50,7 +50,8 @@ exports.Map = class {
                     massTotal: Math.round(player.massTotal),
                     hue: player.hue,
                     id: player.id,
-                    name: player.name
+                    name: player.name,
+                    escrowBalance: player.escrowBalance
                 };
             }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -389,7 +389,8 @@ const updateSpectator = (socketID) => {
         massTotal: 0,
         hue: 100,
         id: socketID,
-        name: ''
+        name: '',
+        escrowBalance: 0
     };
     sockets[socketID].emit('serverTellPlayerMove', playerData, map.players.data, map.food.data, map.massFood.data, map.viruses.data);
     if (leaderboardChanged) {


### PR DESCRIPTION
## Summary
- include escrow balance when server sends player data
- pass wallet data to renderer
- draw wallet value in red beneath the player name

## Testing
- `npm test` *(fails: gulp not found)*