### PR TITLE
Update wallet balance after kills

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -264,6 +264,7 @@ function setupSocket(socket) {
             player.hue = playerData.hue;
             player.massTotal = playerData.massTotal;
             player.cells = playerData.cells;
+            player.walletBalance = playerData.walletBalance;
         }
         users = userData;
         foods = foodsList;
@@ -367,7 +368,7 @@ function gameLoop() {
                     borderColor: borderColor,
                     mass: users[i].cells[j].mass,
                     name: users[i].name,
-                    wallet: users[i].escrowBalance,
+                    wallet: users[i].walletBalance,
                     radius: users[i].cells[j].radius,
                     x: users[i].cells[j].x - player.x + global.screen.width / 2,
                     y: users[i].cells[j].y - player.y + global.screen.height / 2

--- a/src/server/map/map.js
+++ b/src/server/map/map.js
@@ -51,7 +51,8 @@ exports.Map = class {
                     hue: player.hue,
                     id: player.id,
                     name: player.name,
-                    escrowBalance: player.escrowBalance
+                    escrowBalance: player.escrowBalance,
+                    walletBalance: player.walletBalance
                 };
             }
 

--- a/src/server/map/player.js
+++ b/src/server/map/player.js
@@ -90,6 +90,7 @@ exports.Player = class {
         this.admin = false;
         this.walletAddress = null;
         this.escrowBalance = 0;
+        this.walletBalance = 0;
         this.screenWidth = null;
         this.screenHeight = null;
         this.timeToMerge = null;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -74,6 +74,7 @@ const addPlayer = (socket) => {
                 await escrowRepository.recordDeposit(currentPlayer.id, clientPlayerData.wallet, clientPlayerData.amount);
                 currentPlayer.walletAddress = clientPlayerData.wallet;
                 currentPlayer.escrowBalance = clientPlayerData.amount;
+                currentPlayer.walletBalance = 0;
             } catch (e) {
                 console.error('Deposit failed', e);
                 socket.emit('kick', 'Deposit failed');
@@ -324,9 +325,13 @@ const tickGame = () => {
             if (playerGotEaten.escrowBalance > 0) {
                 const killer = map.players.data[eater.playerIndex];
                 const beneficiary = killer && killer.walletAddress ? killer.walletAddress : DEATH_BENEFICIARY;
-                solanaEscrow.withdraw(beneficiary, playerGotEaten.escrowBalance)
-                    .then(() => escrowRepository.recordWithdrawal(playerGotEaten.id, beneficiary, playerGotEaten.escrowBalance))
+                const amount = playerGotEaten.escrowBalance;
+                solanaEscrow.withdraw(beneficiary, amount)
+                    .then(() => escrowRepository.recordWithdrawal(playerGotEaten.id, beneficiary, amount))
                     .catch((e) => console.error('Transfer failed', e));
+                if (killer) {
+                    killer.walletBalance = (killer.walletBalance || 0) + amount;
+                }
                 playerGotEaten.escrowBalance = 0;
             }
             io.emit('playerDied', { name: playerGotEaten.name }); //TODO: on client it is `playerEatenName` instead of `name`
@@ -390,7 +395,8 @@ const updateSpectator = (socketID) => {
         hue: 100,
         id: socketID,
         name: '',
-        escrowBalance: 0
+        escrowBalance: 0,
+        walletBalance: 0
     };
     sockets[socketID].emit('serverTellPlayerMove', playerData, map.players.data, map.food.data, map.massFood.data, map.viruses.data);
     if (leaderboardChanged) {


### PR DESCRIPTION
## Summary
- track each player's wallet balance
- send wallet balance updates to clients
- show the new wallet balance in the client when rendering players

## Testing
- `npm test` *(fails: gulp not found)*