### PR TITLE
Scope chat messages to deposit lobbies

### DIFF
--- a/src/server/map/map.js
+++ b/src/server/map/map.js
@@ -13,6 +13,7 @@ exports.Map = class {
         this.viruses = new exports.virusUtils.VirusManager(config.virus);
         this.massFood = new exports.massFoodUtils.MassFoodManager();
         this.players = new exports.playerUtils.PlayerManager();
+        this.lobbies = new Map();
     }
 
     balanceMass(foodMass, gameMass, maxFood, maxVirus) {
@@ -69,5 +70,25 @@ exports.Map = class {
 
             callback(extractData(currentPlayer), visiblePlayers, visibleFood, visibleMass, visibleViruses);
         }
+    }
+
+    addSocketToLobby(depositOption, socketId) {
+        if (!this.lobbies.has(depositOption)) {
+            this.lobbies.set(depositOption, new Set());
+        }
+        this.lobbies.get(depositOption).add(socketId);
+    }
+
+    removeSocketFromLobby(depositOption, socketId) {
+        if (!this.lobbies.has(depositOption)) return;
+        const lobby = this.lobbies.get(depositOption);
+        lobby.delete(socketId);
+        if (lobby.size === 0) {
+            this.lobbies.delete(depositOption);
+        }
+    }
+
+    getLobbySockets(depositOption) {
+        return this.lobbies.get(depositOption) || new Set();
     }
 }


### PR DESCRIPTION
## Summary
- track sockets by lobby in the Map class
- add/remove socket IDs from lobby when players connect/disconnect
- send chat messages only to sockets in the same lobby

## Testing
- `npm test` *(fails: gulp not found)*
- `npx gulp test` *(fails: network access required)*