### PR TITLE
Implement lobby-specific leaderboards

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -228,7 +228,11 @@ function setupSocket(socket) {
 
     socket.on('leaderboard', (data) => {
         leaderboard = data.leaderboard;
-        var status = '<span class="title">Leaderboard</span>';
+        var title = 'Leaderboard';
+        if (data.depositOption !== undefined) {
+            title += ' (' + data.depositOption + ' SOL)';
+        }
+        var status = '<span class="title">' + title + '</span>';
         for (var i = 0; i < leaderboard.length; i++) {
             status += '<br />';
             if (leaderboard[i].id == player.id) {

--- a/src/server/map/map.js
+++ b/src/server/map/map.js
@@ -13,6 +13,9 @@ exports.Map = class {
         this.viruses = new exports.virusUtils.VirusManager(config.virus);
         this.massFood = new exports.massFoodUtils.MassFoodManager();
         this.players = new exports.playerUtils.PlayerManager();
+        this.leaderboards = {};
+        this.leaderboardChanged = {};
+        this.lobbyPlayerCount = {};
     }
 
     balanceMass(foodMass, gameMass, maxFood, maxVirus) {
@@ -52,7 +55,8 @@ exports.Map = class {
                     id: player.id,
                     name: player.name,
                     escrowBalance: player.escrowBalance,
-                    walletBalance: player.walletBalance
+                    walletBalance: player.walletBalance,
+                    depositOption: player.depositOption
                 };
             }
 
@@ -69,5 +73,55 @@ exports.Map = class {
 
             callback(extractData(currentPlayer), visiblePlayers, visibleFood, visibleMass, visibleViruses);
         }
+    }
+
+    calculateLeaderboards() {
+        const topPlayers = this.players.getTopPlayersByLobby();
+
+        const playerCounts = {};
+        for (const player of this.players.data) {
+            if (!playerCounts[player.depositOption]) playerCounts[player.depositOption] = 0;
+            playerCounts[player.depositOption]++;
+        }
+        this.lobbyPlayerCount = playerCounts;
+
+        const existingLobbies = new Set(Object.keys(this.leaderboards));
+        for (const lobby in topPlayers) {
+            existingLobbies.delete(lobby);
+            const top = topPlayers[lobby];
+            const current = this.leaderboards[lobby] || [];
+            let changed = current.length !== top.length;
+            if (!changed) {
+                for (let i = 0; i < top.length; i++) {
+                    if (current[i].id !== top[i].id) { changed = true; break; }
+                }
+            }
+            if (changed) {
+                this.leaderboards[lobby] = top;
+                this.leaderboardChanged[lobby] = true;
+            }
+        }
+        // remove leaderboards for empty lobbies
+        for (const lobby of existingLobbies) {
+            delete this.leaderboards[lobby];
+            delete this.leaderboardChanged[lobby];
+            delete this.lobbyPlayerCount[lobby];
+        }
+    }
+
+    hasLeaderboardChanged(lobby) {
+        return !!this.leaderboardChanged[lobby];
+    }
+
+    getLeaderboard(lobby) {
+        return this.leaderboards[lobby] || [];
+    }
+
+    getLobbyPlayerCount(lobby) {
+        return this.lobbyPlayerCount[lobby] || 0;
+    }
+
+    resetLeaderboardChanges() {
+        this.leaderboardChanged = {};
     }
 }

--- a/src/server/map/player.js
+++ b/src/server/map/player.js
@@ -347,6 +347,26 @@ exports.PlayerManager = class {
         return topPlayers;
     }
 
+    getTopPlayersByLobby() {
+        const playersByLobby = {};
+        for (const player of this.data) {
+            if (!playersByLobby[player.depositOption]) {
+                playersByLobby[player.depositOption] = [];
+            }
+            playersByLobby[player.depositOption].push(player);
+        }
+
+        const result = {};
+        for (const lobby in playersByLobby) {
+            playersByLobby[lobby].sort((a, b) => b.massTotal - a.massTotal);
+            result[lobby] = playersByLobby[lobby]
+                .slice(0, 10)
+                .map(p => ({ id: p.id, name: p.name }));
+        }
+
+        return result;
+    }
+
     getTotalMass() {
         let result = 0;
         for (let player of this.data) {


### PR DESCRIPTION
## Summary
- add helper `PlayerManager.getTopPlayersByLobby`
- track and compute lobby leaderboards in `Map`
- send lobby leaderboard updates from server
- show deposit amount in leaderboard title on the client
- fix missing semicolon in `sendLeaderboard`

## Testing
- `npm test` *(fails: gulp not found)*