### PR TITLE
Fix unmatched parenthesis in server.js

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -355,6 +355,7 @@ const tickGame = () => {
             map.players.removePlayerByIndex(gotEaten.playerIndex);
         }
     });
+    });
 
 };
 


### PR DESCRIPTION
## Summary
- add missing closing `forEach` parenthesis in `server.js`

## Testing
- `node -c src/server/server.js`
- `npm test` *(fails: `gulp` not found)*